### PR TITLE
lint: better import order group

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -1,9 +1,10 @@
 package common
 
 import (
-	"github.com/google/uuid"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 var StartTime = time.Now().Unix() // unit: second

--- a/common/embed-file-system.go
+++ b/common/embed-file-system.go
@@ -2,9 +2,10 @@ package common
 
 import (
 	"embed"
-	"github.com/gin-contrib/static"
 	"io/fs"
 	"net/http"
+
+	"github.com/gin-contrib/static"
 )
 
 // Credit: https://github.com/gin-contrib/static/issues/19

--- a/common/logger.go
+++ b/common/logger.go
@@ -2,12 +2,13 @@ package common
 
 import (
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/gin-gonic/gin"
 )
 
 func SetupGinLog() {

--- a/common/redis.go
+++ b/common/redis.go
@@ -2,9 +2,10 @@ package common
 
 import (
 	"context"
-	"github.com/go-redis/redis/v8"
 	"os"
 	"time"
+
+	"github.com/go-redis/redis/v8"
 )
 
 var RDB *redis.Client

--- a/common/utils.go
+++ b/common/utils.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"github.com/google/uuid"
 	"html/template"
 	"log"
 	"net"
@@ -10,6 +9,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 func OpenBrowser(url string) {

--- a/common/verification.go
+++ b/common/verification.go
@@ -1,10 +1,11 @@
 package common
 
 import (
-	"github.com/google/uuid"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type verificationValue struct {

--- a/controller/file.go
+++ b/controller/file.go
@@ -2,14 +2,16 @@ package controller
 
 import (
 	"fmt"
-	"gin-template/common"
-	"gin-template/model"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	"gin-template/common"
+	"gin-template/model"
+
+	"github.com/gin-gonic/gin"
 )
 
 func GetAllFiles(c *gin.Context) {

--- a/controller/github.go
+++ b/controller/github.go
@@ -5,13 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"gin-template/common"
-	"gin-template/model"
-	"github.com/gin-contrib/sessions"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"strconv"
 	"time"
+
+	"gin-template/common"
+	"gin-template/model"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
 )
 
 type GitHubOAuthResponse struct {

--- a/controller/misc.go
+++ b/controller/misc.go
@@ -3,10 +3,12 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"gin-template/common"
 	"gin-template/model"
+
 	"github.com/gin-gonic/gin"
-	"net/http"
 )
 
 func GetStatus(c *gin.Context) {

--- a/controller/option.go
+++ b/controller/option.go
@@ -2,11 +2,13 @@ package controller
 
 import (
 	"encoding/json"
-	"gin-template/common"
-	"gin-template/model"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"strings"
+
+	"gin-template/common"
+	"gin-template/model"
+
+	"github.com/gin-gonic/gin"
 )
 
 func GetOptions(c *gin.Context) {

--- a/controller/user.go
+++ b/controller/user.go
@@ -2,14 +2,16 @@ package controller
 
 import (
 	"encoding/json"
-	"gin-template/common"
-	"gin-template/model"
-	"github.com/gin-contrib/sessions"
-	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"gin-template/common"
+	"gin-template/model"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 )
 
 type LoginRequest struct {

--- a/controller/wechat.go
+++ b/controller/wechat.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"gin-template/common"
-	"gin-template/model"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"strconv"
 	"time"
+
+	"gin-template/common"
+	"gin-template/model"
+
+	"github.com/gin-gonic/gin"
 )
 
 type wechatLoginResponse struct {

--- a/main.go
+++ b/main.go
@@ -2,17 +2,19 @@ package main
 
 import (
 	"embed"
+	"log"
+	"os"
+	"strconv"
+
 	"gin-template/common"
 	"gin-template/middleware"
 	"gin-template/model"
 	"gin-template/router"
+
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-contrib/sessions/redis"
 	"github.com/gin-gonic/gin"
-	"log"
-	"os"
-	"strconv"
 )
 
 //go:embed web/build

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -1,11 +1,13 @@
 package middleware
 
 import (
+	"net/http"
+
 	"gin-template/common"
 	"gin-template/model"
+
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
-	"net/http"
 )
 
 func authHelper(c *gin.Context, minRole int) {

--- a/middleware/rate-limit.go
+++ b/middleware/rate-limit.go
@@ -3,10 +3,12 @@ package middleware
 import (
 	"context"
 	"fmt"
-	"gin-template/common"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"time"
+
+	"gin-template/common"
+
+	"github.com/gin-gonic/gin"
 )
 
 var timeFormat = "2006-01-02T15:04:05.000Z"

--- a/middleware/turnstile-check.go
+++ b/middleware/turnstile-check.go
@@ -2,11 +2,13 @@ package middleware
 
 import (
 	"encoding/json"
-	"gin-template/common"
-	"github.com/gin-contrib/sessions"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"net/url"
+
+	"gin-template/common"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
 )
 
 type turnstileCheckResponse struct {

--- a/model/file.go
+++ b/model/file.go
@@ -1,11 +1,13 @@
 package model
 
 import (
-	"gin-template/common"
-	_ "gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 	"os"
 	"path"
+
+	"gin-template/common"
+
+	_ "gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 type File struct {

--- a/model/main.go
+++ b/model/main.go
@@ -1,11 +1,13 @@
 package model
 
 import (
+	"os"
+
 	"gin-template/common"
+
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"os"
 )
 
 var DB *gorm.DB

--- a/model/option.go
+++ b/model/option.go
@@ -1,9 +1,10 @@
 package model
 
 import (
-	"gin-template/common"
 	"strconv"
 	"strings"
+
+	"gin-template/common"
 )
 
 type Option struct {

--- a/model/user.go
+++ b/model/user.go
@@ -2,8 +2,9 @@ package model
 
 import (
 	"errors"
-	"gin-template/common"
 	"strings"
+
+	"gin-template/common"
 )
 
 // User if you add sensitive fields, don't forget to clean them in setupLogin function.

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -3,6 +3,7 @@ package router
 import (
 	"gin-template/controller"
 	"gin-template/middleware"
+
 	"github.com/gin-gonic/gin"
 )
 

--- a/router/main.go
+++ b/router/main.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"embed"
+
 	"github.com/gin-gonic/gin"
 )
 

--- a/router/web-router.go
+++ b/router/web-router.go
@@ -2,12 +2,14 @@ package router
 
 import (
 	"embed"
+	"net/http"
+
 	"gin-template/common"
 	"gin-template/controller"
 	"gin-template/middleware"
+
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
-	"net/http"
 )
 
 func setWebRouter(router *gin.Engine, buildFS embed.FS, indexPage []byte) {


### PR DESCRIPTION
import group 进行区域区分，分别分为 3 部分：
1. go sdk 库
2. 当前库，即 gin-template/xxx package
3. 第三方依赖库

大部分代码最佳规范都有做相应的 import group 标准：
uber-go 参考实践：https://github.com/uber-go/guide/blob/master/style.md#import-group-ordering